### PR TITLE
確認ダイアログを OK/Cancel 以外で閉じたときにコマンドアイコンが非活性のままになる

### DIFF
--- a/RHarbor/MvvmDialog/MvvmDialogBehavior.cs
+++ b/RHarbor/MvvmDialog/MvvmDialogBehavior.cs
@@ -95,6 +95,8 @@ namespace kenzauros.RHarbor.MvvmDialog
         {
             if (Content != null) // Window Close Button or Alt+F4 or etc.
             {
+                // Invoke to assure a WaitHandle has been set since OnClose won't be called when Window closed not by commands
+                (Content as IDialog)?.CloseWindow();
                 Content = null;
             }
         }

--- a/RHarbor/Properties/AssemblyInfo.cs
+++ b/RHarbor/Properties/AssemblyInfo.cs
@@ -51,4 +51,4 @@ using System.Windows;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.7")]
+[assembly: AssemblyVersion("1.0.8")]

--- a/RHarbor/ViewModels/ConnectionInfoManagementViewModels/ConnectionInfoManagementViewModel.cs
+++ b/RHarbor/ViewModels/ConnectionInfoManagementViewModels/ConnectionInfoManagementViewModel.cs
@@ -21,8 +21,8 @@ namespace kenzauros.RHarbor.ViewModels
         public ObservableCollection<T> Items { get; set; } = new ObservableCollection<T>();
         public ReactiveProperty<string> FilterText { get; set; } = new ReactiveProperty<string>();
 
-        public AsyncReactiveCommand<T> RemoveItemCommand { get; set; } = new AsyncReactiveCommand<T>();
-        public AsyncReactiveCommand<T> ConnectCommand { get; set; } = new AsyncReactiveCommand<T>();
+        public ReactiveCommand<T> RemoveItemCommand { get; set; } = new ReactiveCommand<T>();
+        public ReactiveCommand<T> ConnectCommand { get; set; } = new ReactiveCommand<T>();
 
         public ReactiveCommand StartEditCommand { get; set; }
         public ReactiveProperty<T> SelectedItem { get; set; } = new ReactiveProperty<T>();
@@ -51,7 +51,7 @@ namespace kenzauros.RHarbor.ViewModels
                 }
             }).AddTo(Disposable);
 
-            ConnectCommand.Subscribe(item => Connect(item)).AddTo(Disposable);
+            ConnectCommand.Subscribe(async item => await Connect(item)).AddTo(Disposable);
 
             IsItemSelected = SelectedItem.Select(x => x != null).ToReadOnlyReactiveProperty();
 


### PR DESCRIPTION
fix #23

#23 でご報告いただいた内容を修正しました。
併せて、接続中に接続ボタンを非活性にしないようにしました。